### PR TITLE
Improve participant text processing

### DIFF
--- a/retrochatbot/framework/domain/usecases/keys_to_text.py
+++ b/retrochatbot/framework/domain/usecases/keys_to_text.py
@@ -1,15 +1,32 @@
+import datetime as dt
+
+from retrochatbot.botapi.participant_texts import ParticipantText, ParticipantTexts
+
 KEY_BACKSPACE = "Backspace"
 KEY_ENTER = "Enter"
 
 
-def keys_to_text(keys: list[str]) -> str:
-    result: list[str] = []
+def keys_to_text(
+    participant_name: str, keys: list[str | dt.datetime]
+) -> ParticipantTexts:
+    result: ParticipantTexts = []
+    cur_text: list[str] = []
     for key in keys:
-        if key == KEY_BACKSPACE and len(result) > 0:
-            result.pop()
+        if key == KEY_BACKSPACE and len(cur_text) > 0:
+            cur_text.pop()
         elif key == KEY_ENTER:
-            result.append("\n")
-        elif len(key) == 1:
-            result.append(key)
+            cur_text.append("\n")
+        elif isinstance(key, str) and len(key) == 1:
+            cur_text.append(key)
+        elif isinstance(key, dt.datetime):
+            if cur_text:
+                result.append(
+                    ParticipantText(
+                        participant_name=participant_name,
+                        text="".join(cur_text),
+                        last_event_datetime=key,
+                    )
+                )
+            cur_text = []
         # else ignore other keys
-    return "".join(result)
+    return result

--- a/retrochatbot/framework/domain/usecases/participant_buffer_texts.py
+++ b/retrochatbot/framework/domain/usecases/participant_buffer_texts.py
@@ -1,4 +1,6 @@
-from retrochatbot.botapi.participant_texts import ParticipantText, ParticipantTexts
+import itertools
+
+from retrochatbot.botapi.participant_texts import ParticipantTexts
 from retrochatbot.framework.domain.entities.participant_buffer import ParticipantBuffer
 from retrochatbot.framework.domain.repositories.room_repository import RoomRepository
 from retrochatbot.framework.domain.usecases import keys_to_text
@@ -9,17 +11,17 @@ def merge_participant_buffer_texts(
     buffers: dict[str, ParticipantBuffer],
 ) -> ParticipantTexts:
     """
-    :return: a list of participant name to buffer text.
+    :return: the texts of the different participants, ordered by timestamp.
     """
     return sorted(
-        [
-            ParticipantText(
-                participant_name=repo.get_participant_name(participant_id),
-                text=keys_to_text(buffer.data.data),
-                last_event_datetime=buffer.last_event_datetime,
-            )
-            for (participant_id, buffer) in buffers.items()
-            if buffer.last_event_datetime
-        ],
+        itertools.chain(
+            *[
+                keys_to_text(
+                    participant_name=repo.get_participant_name(participant_id),
+                    keys=buffer.data.data,
+                )
+                for (participant_id, buffer) in buffers.items()
+            ]
+        ),
         key=lambda x: x.last_event_datetime,
     )

--- a/tests/domain/usecases/test_keys_to_text.py
+++ b/tests/domain/usecases/test_keys_to_text.py
@@ -1,40 +1,109 @@
+import datetime as dt
+
 import pytest
 
+from retrochatbot.botapi.participant_texts import ParticipantText, ParticipantTexts
 from retrochatbot.framework.domain.usecases import (
     KEY_BACKSPACE,
     KEY_ENTER,
     keys_to_text,
 )
 
+DATETIME_PAST_1 = dt.datetime(1996, 1, 1, 11, 55, 0)
+DATETIME_PAST_2 = dt.datetime(1996, 1, 1, 11, 57, 0)
+
 
 @pytest.mark.parametrize(
     argnames=["input_keys", "expected_text"],
     argvalues=[
         [
-            ["h", "e", "l", "l", "o"],
-            "hello",
+            ["h", "e", "l", "l", "o", DATETIME_PAST_1],
+            [
+                ParticipantText(
+                    participant_name="jdoe",
+                    text="hello",
+                    last_event_datetime=DATETIME_PAST_1,
+                )
+            ],
         ],
         [
-            ["h", "e", "l", "l", "o", KEY_BACKSPACE],
-            "hell",
+            ["h", "e", "l", "l", "o", KEY_BACKSPACE, DATETIME_PAST_1],
+            [
+                ParticipantText(
+                    participant_name="jdoe",
+                    text="hell",
+                    last_event_datetime=DATETIME_PAST_1,
+                )
+            ],
         ],
         [
-            ["h", "e", "l", "l", "o", KEY_BACKSPACE, KEY_ENTER],
-            "hell\n",
+            ["h", "e", "l", "l", "o", KEY_BACKSPACE, KEY_ENTER, DATETIME_PAST_1],
+            [
+                ParticipantText(
+                    participant_name="jdoe",
+                    text="hell\n",
+                    last_event_datetime=DATETIME_PAST_1,
+                )
+            ],
         ],
         [
-            ["a", KEY_BACKSPACE, KEY_BACKSPACE],
-            "",
+            ["a", KEY_BACKSPACE, KEY_BACKSPACE, DATETIME_PAST_1],
+            [],
         ],
         [
-            ["a", "Meta"],
-            "a",
+            ["a", "Meta", DATETIME_PAST_1],
+            [
+                ParticipantText(
+                    participant_name="jdoe",
+                    text="a",
+                    last_event_datetime=DATETIME_PAST_1,
+                )
+            ],
+        ],
+        [
+            ["h", "i", DATETIME_PAST_1],
+            [
+                ParticipantText(
+                    participant_name="jdoe",
+                    text="hi",
+                    last_event_datetime=DATETIME_PAST_1,
+                )
+            ],
+        ],
+        [
+            ["h", "i", DATETIME_PAST_1, "h", "i", "?"],
+            [
+                ParticipantText(
+                    participant_name="jdoe",
+                    text="hi",
+                    last_event_datetime=DATETIME_PAST_1,
+                ),
+            ],
+        ],
+        [
+            ["h", "i", DATETIME_PAST_1, "h", "i", "?", DATETIME_PAST_2],
+            [
+                ParticipantText(
+                    participant_name="jdoe",
+                    text="hi",
+                    last_event_datetime=DATETIME_PAST_1,
+                ),
+                ParticipantText(
+                    participant_name="jdoe",
+                    text="hi?",
+                    last_event_datetime=DATETIME_PAST_2,
+                ),
+            ],
         ],
     ],
 )
 def test_keys_to_text(
     input_keys: list[str],
-    expected_text: str,
+    expected_text: ParticipantTexts,
 ):
-    actual_text = keys_to_text(keys=input_keys)
+
+    actual_text = keys_to_text(
+        participant_name="jdoe",
+        keys=input_keys,
+    )
     assert actual_text == expected_text


### PR DESCRIPTION
* Split a participant's text buffer into multiple timestamped messages, based on debouncing. When a user stops typing, that ends the current message and adds a timestamp to it.
* Simplify the prompts sent to chatgpt. Include the usernames inside the metadata provided for this purpose.
* Don't include the number of participants in the prompt.
* Add a trailing space to messages sent to the chat from the bot