### PR TITLE
Fix a bug where newlines were incorrently sent to the chat server

### DIFF
--- a/retrochatbot/framework/domain/entities/special_keys.py
+++ b/retrochatbot/framework/domain/entities/special_keys.py
@@ -1,0 +1,2 @@
+KEY_BACKSPACE = "Backspace"
+KEY_ENTER = "Enter"

--- a/retrochatbot/framework/domain/usecases/buffer_data_to_participant_texts.py
+++ b/retrochatbot/framework/domain/usecases/buffer_data_to_participant_texts.py
@@ -1,9 +1,7 @@
 import datetime as dt
 
 from retrochatbot.botapi.participant_texts import ParticipantText, ParticipantTexts
-
-KEY_BACKSPACE = "Backspace"
-KEY_ENTER = "Enter"
+from retrochatbot.framework.domain.entities.special_keys import KEY_BACKSPACE, KEY_ENTER
 
 
 def buffer_data_to_participant_texts(

--- a/retrochatbot/framework/infrastructure/socketio_room_adapter.py
+++ b/retrochatbot/framework/infrastructure/socketio_room_adapter.py
@@ -5,6 +5,7 @@ from socketio import AsyncClientNamespace
 from retrochatbot.framework.domain.adapters.room_adapter import RoomAdapter
 from retrochatbot.framework.domain.entities.key_typed_event import KeyTypedEvent
 from retrochatbot.framework.domain.entities.participant import Participant
+from retrochatbot.framework.domain.entities.special_keys import KEY_ENTER
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +39,8 @@ class SocketIoRoomAdapter(RoomAdapter, AsyncClientNamespace):
         self,
         text: str,
     ):
-        for key in text:
+        for char in text:
+            key = KEY_ENTER if char in "\r\n" else char
             await self.emit(
                 event="typed",
                 data={


### PR DESCRIPTION
Send the special key "Enter" when the bot supplies a newline or carriage return character.

Related PRs:
* https://github.com/caarmen/retro-chat/pull/12
* https://github.com/caarmen/retro-chat-bot/pull/4